### PR TITLE
IS-2178: Add vurdering oppfylt pdf

### DIFF
--- a/data/isarbeidsuforhet/vurdering-av-arbeidsuforhet.json
+++ b/data/isarbeidsuforhet/vurdering-av-arbeidsuforhet.json
@@ -1,0 +1,19 @@
+{
+  "mottakerNavn": "Artig Trane",
+  "mottakerFodselsnummer": "12345678945",
+  "datoSendt": "19. september 2023",
+  "documentComponents": [
+    {
+      "type": "HEADER_H1",
+      "texts": ["Vurdering av arbeidsuførhet"]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": ["Her kommer friteksten som veileder skriver inn."]
+    },
+    {
+      "type": "PARAGRAPH",
+      "texts": ["Med vennlig hilsen", "Kari Saksbehandler", "NAV"]
+    }
+  ]
+}

--- a/templates/isarbeidsuforhet/partials/vurdering-base.hbs
+++ b/templates/isarbeidsuforhet/partials/vurdering-base.hbs
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="no">
+{{> isarbeidsuforhet/partials/head }}
+<body>
+    {{> isarbeidsuforhet/partials/content }}
+</body>
+</html>

--- a/templates/isarbeidsuforhet/vurdering-av-arbeidsuforhet.hbs
+++ b/templates/isarbeidsuforhet/vurdering-av-arbeidsuforhet.hbs
@@ -1,0 +1,1 @@
+{{> isarbeidsuforhet/partials/vurdering-base doctitle="Vurdering av arbeidsuførhet"}}


### PR DESCRIPTION
Venter på avklaring med Ingrid ila dagen på hvordan dokumentet skal se ut og riktige ordlyder, men ellers er det en slags kopi av aktivitetskrav-dokumentet (uten `til:` `fnr:` og `dato sendt` felter i dokumentet)

<img width="717" alt="image" src="https://github.com/navikt/isarbeidsuforhetpdfgen/assets/37441744/c22e8b79-c960-41dc-baf4-2909c68a057d">
